### PR TITLE
Fixes bug that leads to negative RPDs for negative cost values

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -3,7 +3,7 @@ calculate_rpd <- function(x)
   x <- as.matrix(x)
   x[is.infinite(x)] <- NA # Remove infinities
   min_cols <- matrixStats::rowMins(x, na.rm = TRUE)
-  100 * (x - min_cols) / min_cols
+  100 * abs((x - min_cols) / min_cols)
 }
 
 orca_pdf <- function(filename, plot)


### PR DESCRIPTION
I'm using `iraceplot` to visualize the `irace` data of an algorithm maximizing its objective function.
Following the `irace` documentation (p.56), I multiplied the algorithm's objective value by -1, as `irace` 
always has the goal of minimizing the cost.
Consequently, the modified outputs of my algorithm are negative costs.
This leads to issues with the RPD calculation in `iraceplot`.
We get negative RDPs (see attached image), which I consider counterintuitive. 
![newplot](https://github.com/auto-optimization/iraceplot/assets/29704088/4c410653-14db-4a54-a7e7-7cb72a22551c)
From my understanding, the RDP should express how much the corresponding configuration's solutions 
deviated from the best-found solution - thus, it assuming negative values is counterintuitive to me.
Hence, I modified the RDP to always take the absolute value of the fraction that it calculates,
which fixed the problem for my use case.
Please let me know if I misunderstood something and that is not how you intended the RDP to be interpreted.

Thanks a lot for developing `irace` and `iraceplot`, they have been of great value to me!
